### PR TITLE
Implement result caching for assertions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.ruff_cache
 /.venv
 __pycache__
+.intentguard

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@
   - Detailed reasoning for why assertions failed
   - Suggestions for fixing the issues
 
-- [ ] Result Caching (https://github.com/kdunee/intentguard/issues/3)
+- [x] Result Caching (https://github.com/kdunee/intentguard/issues/3)
   - Speed up local execution by caching assertion results
   - Avoid redundant LLM calls for unchanged code
 

--- a/intentguard/cache.py
+++ b/intentguard/cache.py
@@ -1,0 +1,44 @@
+import os
+import hashlib
+import json
+
+CACHE_DIR = ".intentguard"
+
+
+def ensure_cache_dir_exists():
+    if not os.path.exists(CACHE_DIR):
+        os.makedirs(CACHE_DIR)
+
+
+def generate_cache_key(expectation: str, objects_text: str, options) -> str:
+    key_string = f"{expectation}:{objects_text}:{options.model}:{options.quorum_size}"
+    return hashlib.sha256(key_string.encode()).hexdigest()
+
+
+def read_cache(cache_key: str):
+    ensure_cache_dir_exists()
+    cache_file = os.path.join(CACHE_DIR, cache_key)
+    if os.path.exists(cache_file):
+        with open(cache_file, "r") as f:
+            return json.load(f)
+    return None
+
+
+def write_cache(cache_key: str, result):
+    ensure_cache_dir_exists()
+    cache_file = os.path.join(CACHE_DIR, cache_key)
+    with open(cache_file, "w") as f:
+        json.dump(result, f)
+
+
+class CachedResult:
+    def __init__(self, result: bool, explanation: str = ""):
+        self.result = result
+        self.explanation = explanation
+
+    def to_dict(self):
+        return {"result": self.result, "explanation": self.explanation}
+
+    @classmethod
+    def from_dict(cls, data: dict):
+        return cls(result=data["result"], explanation=data.get("explanation", ""))

--- a/intentguard/cache.py
+++ b/intentguard/cache.py
@@ -1,21 +1,57 @@
+"""
+This module implements a caching system for IntentGuard results to avoid redundant API calls.
+It stores results in JSON files within a .intentguard directory, using SHA-256 hashes as cache keys.
+"""
+
 import os
 import hashlib
 import json
 
+# Directory where cache files will be stored
 CACHE_DIR = ".intentguard"
 
 
 def ensure_cache_dir_exists():
+    """
+    Creates the cache directory if it doesn't exist.
+    This is called before any cache operations to ensure the cache directory is available.
+    """
     if not os.path.exists(CACHE_DIR):
         os.makedirs(CACHE_DIR)
 
 
 def generate_cache_key(expectation: str, objects_text: str, options) -> str:
-    key_string = f"{expectation}:{objects_text}:{options.model}:{options.quorum_size}"
+    """
+    Generates a unique cache key based on the input parameters and model configuration.
+
+    The key includes a version prefix ('v1') to allow for cache invalidation if the
+    caching logic changes in future versions of the software. This ensures old cached
+    results won't be used if they're incompatible with newer versions.
+
+    Args:
+        expectation (str): The expectation string being tested
+        objects_text (str): The text of the objects being analyzed
+        options: Configuration object containing model and quorum settings
+
+    Returns:
+        str: A SHA-256 hash that serves as the cache key
+    """
+    key_string = (
+        f"v1:{expectation}:{objects_text}:{options.model}:{options.quorum_size}"
+    )
     return hashlib.sha256(key_string.encode()).hexdigest()
 
 
 def read_cache(cache_key: str):
+    """
+    Retrieves cached results for a given cache key.
+
+    Args:
+        cache_key (str): The SHA-256 hash key to look up
+
+    Returns:
+        dict: The cached result if found, None otherwise
+    """
     ensure_cache_dir_exists()
     cache_file = os.path.join(CACHE_DIR, cache_key)
     if os.path.exists(cache_file):
@@ -25,6 +61,13 @@ def read_cache(cache_key: str):
 
 
 def write_cache(cache_key: str, result):
+    """
+    Stores a result in the cache using the provided cache key.
+
+    Args:
+        cache_key (str): The SHA-256 hash key to store the result under
+        result: The data to cache (must be JSON serializable)
+    """
     ensure_cache_dir_exists()
     cache_file = os.path.join(CACHE_DIR, cache_key)
     with open(cache_file, "w") as f:
@@ -32,13 +75,42 @@ def write_cache(cache_key: str, result):
 
 
 class CachedResult:
+    """
+    Represents a cached IntentGuard verification result.
+
+    This class provides a structured way to store and serialize verification results,
+    including both the boolean outcome and any explanation text.
+    """
+
     def __init__(self, result: bool, explanation: str = ""):
+        """
+        Initialize a new CachedResult instance.
+
+        Args:
+            result (bool): The verification result (True/False)
+            explanation (str, optional): Explanation of the result. Defaults to empty string.
+        """
         self.result = result
         self.explanation = explanation
 
     def to_dict(self):
+        """
+        Converts the CachedResult instance to a dictionary for JSON serialization.
+
+        Returns:
+            dict: Dictionary containing the result and explanation
+        """
         return {"result": self.result, "explanation": self.explanation}
 
     @classmethod
     def from_dict(cls, data: dict):
+        """
+        Creates a CachedResult instance from a dictionary.
+
+        Args:
+            data (dict): Dictionary containing 'result' and optionally 'explanation'
+
+        Returns:
+            CachedResult: A new CachedResult instance
+        """
         return cls(result=data["result"], explanation=data.get("explanation", ""))

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -39,7 +39,7 @@ class TestCache(unittest.TestCase):
         objects_text = "test_objects_text"
         options = type("Options", (object,), {"model": "test_model", "quorum_size": 1})
         expected_key = hashlib.sha256(
-            f"{expectation}:{objects_text}:test_model:1".encode()
+            f"v1:{expectation}:{objects_text}:test_model:1".encode()
         ).hexdigest()
         generated_key = generate_cache_key(expectation, objects_text, options)
         self.assertEqual(generated_key, expected_key)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,61 @@
+import unittest
+import os
+import json
+import hashlib
+from intentguard.cache import (
+    read_cache,
+    write_cache,
+    generate_cache_key,
+    ensure_cache_dir_exists,
+    CachedResult,
+)
+
+
+class TestCache(unittest.TestCase):
+    def setUp(self):
+        ensure_cache_dir_exists()
+        self.cache_key = "test_key"
+        self.cache_file = os.path.join(".intentguard", self.cache_key)
+        self.test_data = {"result": True}
+
+    def tearDown(self):
+        if os.path.exists(self.cache_file):
+            os.remove(self.cache_file)
+
+    def test_write_cache(self):
+        write_cache(self.cache_key, self.test_data)
+        self.assertTrue(os.path.exists(self.cache_file))
+        with open(self.cache_file, "r") as f:
+            data = json.load(f)
+        self.assertEqual(data, self.test_data)
+
+    def test_read_cache(self):
+        write_cache(self.cache_key, self.test_data)
+        data = read_cache(self.cache_key)
+        self.assertEqual(data, self.test_data)
+
+    def test_generate_cache_key(self):
+        expectation = "test_expectation"
+        objects_text = "test_objects_text"
+        options = type("Options", (object,), {"model": "test_model", "quorum_size": 1})
+        expected_key = hashlib.sha256(
+            f"{expectation}:{objects_text}:test_model:1".encode()
+        ).hexdigest()
+        generated_key = generate_cache_key(expectation, objects_text, options)
+        self.assertEqual(generated_key, expected_key)
+
+    def test_cached_result_to_dict(self):
+        cached_result = CachedResult(result=True, explanation="Test explanation")
+        result_dict = cached_result.to_dict()
+        expected_dict = {"result": True, "explanation": "Test explanation"}
+        self.assertEqual(result_dict, expected_dict)
+
+    def test_cached_result_from_dict(self):
+        data = {"result": True, "explanation": "Test explanation"}
+        cached_result = CachedResult.from_dict(data)
+        self.assertTrue(cached_result.result)
+        self.assertEqual(cached_result.explanation, "Test explanation")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #3

Implement result caching for assertions to avoid redundant LLM calls and improve performance.

* **Caching Mechanism**: Add a caching mechanism for assertion results using the `.intentguard` directory in `intentguard/intentguard.py`. Generate cache keys based on LLM inputs and inference options using a hash function. Handle cache misses and perform LLM calls when necessary. Include explanations in failed assertions in the cache. Use the `CachedResult` class for caching results.
* **Cache Utility Functions**: Add `intentguard/cache.py` to implement functions to read from and write to the cache, generate cache keys using a hash function, and define the `CachedResult` class to store assertion results and explanations.
* **Gitignore Update**: Update `.gitignore` to include the `.intentguard` directory.
* **Tests for Caching**: Add tests in `tests/test_intentguard.py` for caching assertion results, cache key generation, cache retrieval, and cache invalidation. Add `tests/test_cache.py` to implement tests for reading from and writing to the cache, generating cache keys, and the `CachedResult` class.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kdunee/intentguard/issues/3?shareId=25f7d913-7055-4c67-b66f-04b377a3c469).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced caching functionality for assertion results to enhance performance.
	- Updated the roadmap to reflect the completion of the "Result Caching" feature.

- **Bug Fixes**
	- Corrected the handling of cache directory entries in the `.gitignore` file.

- **Tests**
	- Added comprehensive tests for cache operations and validation of the caching mechanism in both `test_cache.py` and `test_intentguard.py`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->